### PR TITLE
fix `dtype object is not allowed` error message when loading loom files created by loomR

### DIFF
--- a/R/internal.R
+++ b/R/internal.R
@@ -57,7 +57,7 @@ getDtype <- function(x) {
     EXPR = class(x = x),
     'numeric' = h5types$double,
     'integer' = h5types$int,
-    'character' = H5T_STRING$new(size = Inf),
+    'character' = H5T_STRING$new(size = max(nchar(x))),
     'logical' = H5T_LOGICAL$new(),
     stop(paste("Unknown data type:", class(x = x)))
   ))

--- a/R/loom.R
+++ b/R/loom.R
@@ -471,7 +471,19 @@ loom <- R6Class(
       # Add the attributes as datasets for our MARGIN's group
       for (i in 1:length(x = attribute)) {
         try(expr = grp$link_delete(name = names(x = attribute)[i]), silent = TRUE)
-        grp[[names(x = attribute)[i]]] <- attribute[[i]]
+
+        if(is.null(dim(attribute[[i]]))){
+          message(paste("Adding :",names(x = attribute)[i]))
+          att = grp$create_dataset(
+                     name = names(x = attribute)[i],
+                     dtype = getDtype(x = attribute[[i]]),
+                     dims = length(attribute[[i]])
+                 )
+
+          att[1:length(attribute[[i]])] = attribute[[i]]
+        } else{
+          grp[[names(x = attribute)[i]]] <- attribute[[i]] 
+        }               
       }
       self$flush()
       gc(verbose = FALSE)


### PR DESCRIPTION
loomR was saving string as a variable length
```r
Datatype: H5T_STRING {
      STRSIZE H5T_VARIABLE;
      STRPAD H5T_STR_NULLTERM;
      CSET H5T_CSET_ASCII;
      CTYPE H5T_C_S1;
   }
```

While the new loompy format require a fixed length, expl

```r
DATATYPE  H5T_STRING {
  STRSIZE 24;
  STRPAD H5T_STR_NULLPAD;
  CSET H5T_CSET_ASCII;
  CTYPE H5T_C_S1;
}
```

Now the files can be opened in loompy

```r
data("pbmc_small")
 Convert(from = pbmc_small, to = "loom", filename = "pbmc_small.loom", 
    display.progress = FALSE)
```
In python
```python
import loompy
lfile = loompy.connect("pbmc_small.loom")
lfile
# <loompy.loompy.LoomConnection at 0x7f30461a7470>
```
